### PR TITLE
MD302X Support

### DIFF
--- a/aircraft-tbm930-improvement/SimObjects/Airplanes/Asobo_TBM930/model/TBM930_interior.xml
+++ b/aircraft-tbm930-improvement/SimObjects/Airplanes/Asobo_TBM930/model/TBM930_interior.xml
@@ -2236,25 +2236,17 @@
       <!-- GLASS_COCKPIT ##############################-->
       <Component ID="GLASS_COCKPIT">
         <Component ID="GLASS_COCKPIT_Screen_Attitude_Text" Node="AttitudeDisplay">
-          <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+          <UseTemplate Name="ASOBO_GT_Material_Emissive_Code">
             <EMISSIVE_CODE>
-              (L:XMLVAR_AS3000_DisplayLightingBool, bool) if{
-                (L:XMLVAR_AS3000_DisplayLighting, Percent over 100) #SCREEN_LIGHT_DIMMING_SCALE# * #MAX_EMISSIVE_PERCENT# #SCREEN_MIN_EMISSIVE_PERCENT# - * #SCREEN_MIN_EMISSIVE_PERCENT# +
-              } els{
-                (L:AS3000_Brightness, Percent over 100) (A:LIGHT POTENTIOMETER:4, Percent over 100) * #SCREEN_LIGHT_DIMMING_SCALE# * #MAX_EMISSIVE_PERCENT# #SCREEN_MIN_EMISSIVE_PERCENT# - * #SCREEN_MIN_EMISSIVE_PERCENT# +
-              }
+                (A:LIGHT POTENTIOMETER:4, Percent over 100) #SCREEN_LIGHT_DIMMING_SCALE# * #MAX_EMISSIVE_PERCENT# #SCREEN_MIN_EMISSIVE_PERCENT# - * #SCREEN_MIN_EMISSIVE_PERCENT# +
             </EMISSIVE_CODE>
           </UseTemplate>
         </Component>
 
         <Component ID="GLASS_COCKPIT_Screen_Speed_Text" Node="SpeedDisplay">
-          <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+          <UseTemplate Name="ASOBO_GT_Material_Emissive_Code">
             <EMISSIVE_CODE>
-              (L:XMLVAR_AS3000_DisplayLightingBool, bool) if{
-                (L:XMLVAR_AS3000_DisplayLighting, Percent over 100) #SCREEN_LIGHT_DIMMING_SCALE# * #MAX_EMISSIVE_PERCENT# #SCREEN_MIN_EMISSIVE_PERCENT# - * #SCREEN_MIN_EMISSIVE_PERCENT# +
-              } els{
-                (L:AS3000_Brightness, Percent over 100) (A:LIGHT POTENTIOMETER:4, Percent over 100) * #SCREEN_LIGHT_DIMMING_SCALE# * #MAX_EMISSIVE_PERCENT# #SCREEN_MIN_EMISSIVE_PERCENT# - * #SCREEN_MIN_EMISSIVE_PERCENT# +
-              }
+                (A:LIGHT POTENTIOMETER:4, Percent over 100) #SCREEN_LIGHT_DIMMING_SCALE# * #MAX_EMISSIVE_PERCENT# #SCREEN_MIN_EMISSIVE_PERCENT# - * #SCREEN_MIN_EMISSIVE_PERCENT# +
             </EMISSIVE_CODE>
           </UseTemplate>
         </Component>


### PR DESCRIPTION
Hello,

I made a mod called [MD302X](https://flightsim.to/file/10190/md302x) that improves the default MD302 unit (aka AS1000 backup). Currently, it adds a one-hour battery that allows the unit to work in case of an electrical failure.

I modified the TBM 930 so it's compatible with it and made the unit brightness adjustable. The modifications should work even if MD302X isn't installed.

ASOBO_GT_Material_Emissive_Code template is used instead of ASOBO_GT_Emissive_Gauge because the latter will set the brightness to zero (effectively shutting down the unit) when there is no electricity, regardless of the battery status.

I removed all AS3000 brightness stuff from the unit brightness control as it won't work when no electricity is available, meaning the unit brightness can't be controlled in that situation. Instead, I directly tied it to the panel light knob.